### PR TITLE
Allow unfree packages globally

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -18,7 +18,8 @@ let lib = import ../../../lib; in lib.makeOverridable (
 
 let
 
-  allowUnfree = config.allowUnfree or false || builtins.getEnv "NIXPKGS_ALLOW_UNFREE" == "1";
+  # allowUnfree = config.allowUnfree or false || builtins.getEnv "NIXPKGS_ALLOW_UNFREE" == "1";
+  allowUnfree = true;
 
   whitelist = config.whitelistedLicenses or [];
   blacklist = config.blacklistedLicenses or [];


### PR DESCRIPTION
This allows the use of unfree packages globally. This eliminates the need to allow this via `~/.nixpkgs/config.nix` or setting `NIXPKGS_ALLOW_UNFREE=1`
