### PR TITLE
[DX]: Allow unfree packages globally

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -18,7 +18,7 @@ let lib = import ../../../lib; in lib.makeOverridable (
 
 let
 
-  allowUnfree = config.allowUnfree or false || builtins.getEnv "NIXPKGS_ALLOW_UNFREE" == "1";
+  allowUnfree = true;
 
   whitelist = config.whitelistedLicenses or [];
   blacklist = config.blacklistedLicenses or [];


### PR DESCRIPTION
This globally overrides limitations for installing packages with unfree licenses. This is mostly a matter of convenience for us.
